### PR TITLE
Included a complier setting in truffle-config.js

### DIFF
--- a/academy/deploy-an-erc20-token-using-truffle.md
+++ b/academy/deploy-an-erc20-token-using-truffle.md
@@ -89,6 +89,11 @@ require('dotenv').config();
 const { MNEMONIC } = process.env;
 const HDWalletProvider = require('@truffle/hdwallet-provider');
 module.exports = {
+  compilers: {
+    solc: {
+      version: "^0.8.2",
+    }
+  },
   networks: {
     testnet: {
       provider: () =>


### PR DESCRIPTION
While following this tutorial, I encountered an error during deployment as truffle attempts to use default complier settings. This results in an error as default Solidity version is v0.5.16 but the tutorial code specifies version `^0.8.2` in the `IoToken.sol` code.